### PR TITLE
Greater flexibility in to_socrata() function

### DIFF
--- a/autocensus/__init__.py
+++ b/autocensus/__init__.py
@@ -372,10 +372,11 @@ class Query:
         output = reduce(change_column_metadata, columns.to_dict(orient='records'), output)
         return output.run()
 
-    def create_new_dataset(self, client, dataframe, name):
+    def create_new_dataset(self, client, dataframe, name, description):
         """Create and publish a dataframe as a new Socrata dataset."""
         revision, output = client.create(
             name=name if name is not None else self.query_name,
+            description=description if description is not None else '',
             attributionLink='https://api.census.gov'
         ).df(dataframe)
         ok, output = self.prepare_output_schema(output)
@@ -401,7 +402,7 @@ class Query:
             logger.error(f'Failed to publish dataset')
         return revision
 
-    def to_socrata(self, domain, *, dataset_id=None, name=None, auth=None, open_in_browser=True):
+    def to_socrata(self, domain, *, dataframe = None, dataset_id=None, name=None, description=None, auth=None, open_in_browser=True):
         """Run query and publish the resulting dataframe to Socrata."""
         # TODO: Refactor into multiple smaller functions
         try:
@@ -410,7 +411,8 @@ class Query:
             message = 'socrata-py must be installed in order to publish to Socrata'
             raise MissingDependencyError(message)
 
-        dataframe = self.run()
+        if dataframe is None:
+            dataframe = self.run()
 
         # Serialize polygons to WKT (avoids issue with three-dimensional geometry)
         try:
@@ -426,7 +428,7 @@ class Query:
         # If no 4x4 was supplied, create a new dataset
         logger.debug('Creating draft on Socrata')
         if dataset_id is None:
-            revision = self.create_new_dataset(client, dataframe, name)
+            revision = self.create_new_dataset(client, dataframe, name, description)
         # Otherwise, update an existing dataset
         else:
             revision = self.update_existing_dataset(client, dataframe, dataset_id)

--- a/autocensus/__init__.py
+++ b/autocensus/__init__.py
@@ -402,7 +402,17 @@ class Query:
             logger.error(f'Failed to publish dataset')
         return revision
 
-    def to_socrata(self, domain, *, dataframe = None, dataset_id=None, name=None, description=None, auth=None, open_in_browser=True):
+    def to_socrata(
+        self,
+        domain,
+        *,
+        dataframe=None,
+        dataset_id=None,
+        name=None,
+        description=None,
+        auth=None,
+        open_in_browser=True
+    ):
         """Run query and publish the resulting dataframe to Socrata."""
         # TODO: Refactor into multiple smaller functions
         try:
@@ -411,6 +421,7 @@ class Query:
             message = 'socrata-py must be installed in order to publish to Socrata'
             raise MissingDependencyError(message)
 
+        # Run query if dataframe hasn't been supplied
         if dataframe is None:
             dataframe = self.run()
 

--- a/readme.md
+++ b/readme.md
@@ -126,7 +126,7 @@ To improve performance across queries, autocensus caches shapefiles on disk by d
 
 ## Publishing to Socrata
 
-If [socrata-py] is installed, you can publish query results directly to Socrata via the method `Query.to_socrata`.
+If [socrata-py] is installed, you can publish query results (or dataframes containing the results of multiple queries) directly to Socrata via the method `Query.to_socrata`.
 
 [socrata-py]: https://github.com/socrata/socrata-py
 
@@ -167,7 +167,8 @@ query = Query(
 # Run query and publish results as a new dataset on Socrata domain
 query.to_socrata(
     'some-domain.data.socrata.com',
-    name='Average Commute Time by Colorado County, 2013–2017'  # Optional
+    name='Average Commute Time by Colorado County, 2013–2017',  # Optional
+    description='5-year estimates from the American Community Survey',  # Optional
 )
 ```
 
@@ -179,6 +180,43 @@ query.to_socrata(
     'some-domain.data.socrata.com',
     dataset_id='xxxx-xxxx'
 )
+```
+
+### Example: Create a new dataset from multiple queries
+
+```python
+import pandas as pd
+
+# configure county-level query
+county_query = Query(
+    estimate=5,
+    years=range(2013, 2018),
+    variables=['DP03_0025E'],
+    for_geo='county:*',
+    in_geo=['state:08'],
+    table='profile'
+)
+county_dataframe = county_query.run()
+
+# configure state-level query
+state_query = Query(
+    estimate=5,
+    years=range(2013, 2018),
+    variables=['DP03_0025E'],
+    for_geo='state:08',
+    table='profile'
+)
+state_dataframe = state_query.run()
+
+# concatenate dataframes and upload to Socrata
+combined_dataframe = pd.concat([county_dataframe,state_dataframe])
+state_query.to_socrata(
+    'some-domain.data.socrata.com',
+    dataframe=combined_dataframe,
+    name='Average Commute Time by Colorado County with Statewide Averages, 2013–2017',  # Optional
+    description='5-year estimates from the American Community Survey',  # Optional
+)
+
 ```
 
 ## Topics


### PR DESCRIPTION
Improvements listed in: https://github.com/socrata/autocensus/issues/5

Note that this currently provides a `dataframe` argument within `to_socrata()`, allowing a pandas df to be uploaded rather than a query result. However, it still requires `to_socrata()` to be called as an attribute of a query object (e.g. `example_query.to_socrata(dataframe=dataframe)`). It may be preferable to be able to call `to_socrata()` on its own if it doesn't depend on `example_query` but this would likely be a larger change to the code.